### PR TITLE
Remove usage of File.exists?

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Install Calibre
-      run: sudo -v && wget -nv -O- https://download.calibre-ebook.com/linux-installer.sh | sudo sh /dev/stdin
+      run: sudo -v && sudo apt-get install -y libegl1 libopengl0 && wget -nv -O- https://download.calibre-ebook.com/linux-installer.sh | sudo sh /dev/stdin
     - name: Install dependencies
       run: bundle install
     - name: Run tests

--- a/lib/epuber/command/build.rb
+++ b/lib/epuber/command/build.rb
@@ -72,7 +72,7 @@ module Epuber
 
             archive_name = compiler.epub_name
 
-            if ::File.exists?(archive_name)
+            if ::File.exist?(archive_name)
               FileUtils.remove_file(archive_name)
             end
 

--- a/lib/epuber/compiler.rb
+++ b/lib/epuber/compiler.rb
@@ -113,7 +113,7 @@ module Epuber
       Dir.chdir(@file_resolver.destination_path) do
         new_paths = @file_resolver.package_files.map(&:pkg_destination_path)
 
-        if ::File.exists?(epub_path)
+        if ::File.exist?(epub_path)
           Zip::File.open(epub_path, true) do |zip_file|
             old_paths = zip_file.instance_eval { @entry_set.entries.map(&:name) }
             diff = old_paths - new_paths

--- a/lib/epuber/compiler/file_types/abstract_file.rb
+++ b/lib/epuber/compiler/file_types/abstract_file.rb
@@ -64,7 +64,7 @@ module Epuber
         # @return nil
         #
         def self.write_to_file?(content, to_path)
-          return true unless File.exists?(to_path)
+          return true unless File.exist?(to_path)
 
           File.read(to_path) != content.to_s
         end

--- a/lib/epuber/lockfile.rb
+++ b/lib/epuber/lockfile.rb
@@ -18,7 +18,7 @@ module Epuber
     # @return [self]
     #
     def self.from_file(file_path)
-      if File.exists?(file_path)
+      if File.exist?(file_path)
         hash = YAML.safe_load(File.read(file_path))
       else
         hash = {}

--- a/lib/epuber/server.rb
+++ b/lib/epuber/server.rb
@@ -485,7 +485,7 @@ module Epuber
     # @param [String] file_path
     #
     def handle_file(file_path)
-      return not_found unless File.exists?(file_path)
+      return not_found unless File.exist?(file_path)
 
       mtime = File.mtime(file_path)
       last_modified(mtime)


### PR DESCRIPTION
Ruby 3.2 removed this method (which was already marked as deprecated).