### PR TITLE
Allow newer css_parser (CVE-2026-53727), RMagick, Rubyzip and UUIDTools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v0.12.3 (2026-08-07)
+
+- Allow to use css_parser v2 and v3 (v3 fixes [CVE-2026-53727](https://github.com/premailer/css_parser/security/advisories/GHSA-9pmc-p236-855h), it is used on Ruby 3.3+)
+
 ## v0.12.2 (2026-02-07)
 
 - Drop usage of `String#mb_chars` because of deprecation on ActiveSupport side

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## v0.12.3 (2026-08-07)
 
 - Allow to use css_parser v2 and v3 (v3 fixes [CVE-2026-53727](https://github.com/premailer/css_parser/security/advisories/GHSA-9pmc-p236-855h), it is used on Ruby 3.3+)
+- Allow to use RMagick v7 (it is used on Ruby 3.2+)
+- Allow to use Rubyzip v3 (it is used on Ruby 3.0+)
+- Allow to use UUIDTools v3
 
 ## v0.12.2 (2026-02-07)
 

--- a/epuber.gemspec
+++ b/epuber.gemspec
@@ -24,15 +24,15 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mime-types', '~> 3.0'
   spec.add_dependency 'nokogiri', '~> 1.8', '>= 1.8.2'
   spec.add_dependency 'os', '~> 1.0'
-  spec.add_dependency 'uuidtools', '~> 2.1'
+  spec.add_dependency 'uuidtools', '>= 2.1', '< 4.0'
 
   spec.add_dependency 'sinatra', '>= 2.0', '< 5.0'
   spec.add_dependency 'sinatra-contrib', '>= 2.0', '< 5.0'
   spec.add_dependency 'sinatra-websocket', '~> 0.3'
   spec.add_dependency 'thin', '>= 1.6', '< 3.0'
 
-  spec.add_dependency 'rmagick', '>= 4.2', '< 7.0'
-  spec.add_dependency 'rubyzip', '~> 2.3'
+  spec.add_dependency 'rmagick', '>= 4.2', '< 8.0'
+  spec.add_dependency 'rubyzip', '>= 2.3', '< 4.0'
 
   spec.add_dependency 'epubcheck-ruby', '>= 4.0', '< 6.0', '!= 5.2.0.0'
 

--- a/epuber.gemspec
+++ b/epuber.gemspec
@@ -38,6 +38,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'bade', '~> 0.3', '>= 0.3.1'
   spec.add_dependency 'coffee-script', '~> 2.4'
-  spec.add_dependency 'css_parser', '>= 0.8', '< 2.0'
+  spec.add_dependency 'css_parser', '>= 0.8', '< 4.0'
   spec.add_dependency 'epuber-stylus', '~> 1.1', '>= 1.1.1'
 end

--- a/lib/epuber/compiler.rb
+++ b/lib/epuber/compiler.rb
@@ -129,8 +129,8 @@ module Epuber
         new_paths = @file_resolver.package_files.map(&:pkg_destination_path)
 
         if ::File.exist?(epub_path)
-          Zip::File.open(epub_path, true) do |zip_file|
-            old_paths = zip_file.instance_eval { @entry_set.entries.map(&:name) }
+          Zip::File.open(epub_path) do |zip_file|
+            old_paths = zip_file.entries.map(&:name)
             diff = old_paths - new_paths
             diff.each do |file_to_remove|
               UI.debug "removing file from result EPUB: #{file_to_remove}"


### PR DESCRIPTION
Resolves the [css_parser Dependabot alert](https://github.com/epuber-io/epuber/security/dependabot/16), then unblocks the other dependencies that our own gemspec was capping below their newest release.

## css_parser — CVE-2026-53727 (high)

`css_parser < 3.0.0` is affected by [GHSA-9pmc-p236-855h](https://github.com/premailer/css_parser/security/advisories/GHSA-9pmc-p236-855h): `read_remote_file` fetches any host/scheme with no filtering and follows `Location:` redirects back into a branch that also services `file://`, turning SSRF into local file disclosure.

**Epuber is not actually exposed** — we only call `load_string!`, never `load_uri!` or `add_block!(base_uri:)`, so the vulnerable sink is unreachable from our code. The constraint is widened regardless so installs pick up the patched 3.x.

`css_parser >= 2.0` requires Ruby >= 3.3, so bundler tiers by Ruby version:

| Ruby | css_parser | Patched |
|---|---|---|
| 3.3+ | 3.0.0 | yes |
| 3.0–3.2 | 1.22.0 | no |
| 2.7 | 1.17.1 | no |

The 1.x tiers were already pinned there by the previous `< 2.0` cap, so no platform loses anything. `required_ruby_version` stays at `>= 2.7`.

> [!NOTE]
> Because the gemspec still permits vulnerable versions for old Ruby, **alert 16 will stay open**. Closing it means raising the floor to Ruby 3.3, which is a separate call.

## Other capped dependencies

These three were the only ones held below their latest release; everything else already allows its newest version.

| Gem | Was | Now | Newest needs |
|---|---|---|---|
| rmagick | `>= 4.2, < 7.0` | `>= 4.2, < 8.0` | Ruby 3.2+, IM 6.9/7.1+ |
| rubyzip | `~> 2.3` | `>= 2.3, < 4.0` | Ruby 3.0+ |
| uuidtools | `~> 2.1` | `>= 2.1, < 4.0` | any |

**Rubyzip v3 was the only one needing code changes** (`Compiler#archive`):

- `Zip::File.open`'s `create` became keyword-only. The positional `true` was redundant — the call is already guarded by `::File.exist?` — so it's dropped rather than version-switched.
- `Zip::File` no longer inherits from `CentralDirectory`, so the `@entry_set` ivar reached via `instance_eval` is gone. Replaced with public `#entries`, present in both 2.4.1 and 3.4.1.

Both forms work unchanged on rubyzip 2.x (what Ruby 2.7 resolves), so one source file covers the whole matrix.

RMagick 7's breaking changes are confined to `Draw`/`RVG`; we only use `Image.read`, `columns`, `rows`, `change_geometry`, `resize!`, `write`. UUIDTools 3 changed MAC discovery and `valid?`; `parse`/`raw` are untouched.

## Verification

275 examples / 0 failures and rubocop clean on 128 files, against css_parser 3.0.0 + rmagick 7.1.1 + rubyzip 3.4.1 + uuidtools 3.0.0 (local Ruby 4.0.6, ImageMagick 7.1.2).

Line coverage showed the suite doesn't reach everything, so the gaps were closed directly:

- **rmagick** — fully covered, including the downscale/resize/write branch.
- **rubyzip** — changed lines covered, but `zip_file.remove` is never exercised. Closed with a standalone test that builds a 3-entry archive, lists, removes and re-verifies contents — passing identically on 2.4.1 and 3.4.1.
- **uuidtools** — `parse(...).raw` is not covered at all. Since it produces an EPUB decryption key, raw bytes were compared across 2.2.0 and 3.0.0 over four UUIDs: byte-identical, same `ArgumentError` on malformed input.

> [!WARNING]
> RMagick 7.1.1 shipped 2026-08-06 — one day before this PR. `< 8.0` pulls it immediately. Pinning `< 7.1` is a reasonable hedge if you'd rather let it settle.
>
> CI installs ImageMagick from apt (IM 6.9.x on ubuntu-latest, which satisfies RMagick 7's floor), but RMagick 7 against IM 6.9 gets its first real exercise on this PR's CI run — local verification used IM 7.1.2.

The CHANGELOG entry is filed under `v0.12.3`; `lib/epuber/version.rb` is left alone, since the version bump is its own commit at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)