### PR TITLE
chore(ci): update GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -8,23 +8,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -36,7 +36,7 @@ jobs:
             type=semver,pattern={{major}}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           push: true
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
         - name: Checkout
-          uses: actions/checkout@v4
+          uses: actions/checkout@v7
 
         - name: Remove ignored files
           run: rm -rf lib/epuber/third_party

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,9 +10,9 @@ jobs:
         ruby: ['4.0', '3.4', '3.3', '3.2', '3.1', '3.0', '2.7']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v7
       with:
         node-version: '20'
 
@@ -23,7 +23,7 @@ jobs:
         rubygems: 3.4.22
 
     - name: Cache Calibre
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: /tmp/calibre-installer-cache
         key: ${{ matrix.os }}-calibre
@@ -36,7 +36,7 @@ jobs:
         wget -nv -O- https://download.calibre-ebook.com/linux-installer.sh | sudo sh /dev/stdin version=6.26.0
 
     - name: Cache bundler
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: vendor
         key: ${{ matrix.os }}-gems-${{ matrix.ruby }}


### PR DESCRIPTION
CI was emitting a deprecation warning on every run:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/cache@v4`, `actions/checkout@v4`, `actions/setup-node@v4`.
> — [changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

Every versioned action is bumped to its current major, all of which run on Node 24.

| Action | Was | Now |
|---|---|---|
| actions/checkout | v4 | **v7** |
| actions/setup-node | v4 | **v7** |
| actions/cache | v4 | **v6** |
| docker/setup-qemu-action | v3 | **v4** |
| docker/setup-buildx-action | v3 | **v4** |
| docker/login-action | v3 | **v4** |
| docker/metadata-action | v5 | **v6** |
| docker/build-push-action | v5 | **v7** |

`docker-release.yml` only runs on `v0.*` tags, so it hadn't produced a warning yet — but it was on the same deprecated runtimes and would have warned on the next release tag.

## Breaking changes reviewed

I read the release notes for every major crossed. None apply here:

- **checkout v7** blocks checking out fork PRs for `pull_request_target` and `workflow_run`. We only use `push` and `pull_request`.
- **setup-node v5+** caches automatically when `package.json` declares a `packageManager` field. There is no `package.json` at the repository root — only a vendored one under `lib/epuber/third_party/`, which the action doesn't look at.
- **setup-buildx v4** removes deprecated inputs/outputs. We pass none.
- **metadata v6** changes how `#` inside list input values is handled. Our `images`/`tags` values contain no `#`; the `#` lines there are YAML comments sitting outside the block scalars.
- **build-push v7** removes the `DOCKER_BUILD_NO_SUMMARY` and `DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs. We set neither.

checkout v5, cache v5 and the docker v4/v6/v7 majors all note a **minimum runner version of 2.327.1**. That only matters for self-hosted runners; everything here is `ubuntu-latest`.

## Left alone

- **`ruby/setup-ruby@v1`** — a moving branch ref (not a tag) that already tracks the current release. Not in the warning.
- **`gaurav-nelson/github-action-markdown-link-check@v1`** — a Docker-based action (`using: 'docker'`), so it has no Node runtime and wasn't part of the warning.

## Verification

All three workflow files still parse as YAML, and every new `uses:` ref was confirmed to resolve to a real tag on its upstream repo. The real check is this PR's own CI run: the warning should be gone from both `Run tests` and `Lint docs`.

> [!NOTE]
> Unrelated to the action versions, but adjacent: [tests.yml](.github/workflows/tests.yml) still pins `node-version: '20'`, and Node 20 went EOL in April 2026. That's the JS runtime `execjs`/`coffee-script` use, not an action runtime, so it isn't part of this warning — left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)